### PR TITLE
footer layout issue fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,9 @@
       </ul>
     </nav>
 
-    <main>
+    <main id="footerControll">
+      <section  id="page">
+
       <div class="welcome-box">
         <img src="http://placehold.it/350x350" alt="logo">
         <h1>Welcome to cmd-kvn Web Dev HQ</h1>
@@ -72,6 +74,8 @@
           <li><a href="mailto:cmd.kvn@gmail.com">Email</a></li>
         </ul>
       </section>
+    </section>
+
     </main>
 
     <footer>Copyright 2016. A Kevin Wong KWeation</footer>

--- a/styles/base.css
+++ b/styles/base.css
@@ -24,9 +24,9 @@ a {
   font-size: 2em;
 }
 
-main {
+#page{
   background-color: rgba(92, 92, 92, 0.8);
-  height: 100%;
+  /*height: 100%;*/
   padding: 3%;
   margin: 0 5%;
 }

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -2,13 +2,17 @@ nav {
 
 }
 
-main {
+#page {
   outline: 1px solid yellow;
   position: relative;
-  height: 100%;
+  /*height: 100%;*/
 }
 
 /*.pull-right {
   outline: 2px dashed blue;
   float: right;
 }*/
+
+#footerControll{
+  min-height: 750px;
+}


### PR DESCRIPTION
fixed footer layout by wrapping content ina section tag within the main tag and adding new style rules.

The height of the 'main' tag was determined by content. on pages without 'enough' content, the footer was not being sufficiently pushed down to the bottom of the page. So if there was not enough content in a given section, the footer would display significantly higher up than the bottom of the page. We wrapped the content of main, ina new container wrapper. we tranfered all css rules for main to this new wrapper and then finally set a min-height css rule for the main tag, forcing the page to always have at least anough height to correctly place the footer.